### PR TITLE
Do not clone repo twice

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-args="--regex --rules regexes.json --entropy=False"
+repo="."
+args="--regex --rules regexes.json --entropy=False --repo_path=${repo}"
 
 if [ -n "${INPUT_BRANCH}" ]; then
   args="${args} --branch ${INPUT_BRANCH}"
 fi
 
 cp /regexes.json .
-/usr/local/bin/trufflehog ${args} .
+/usr/local/bin/trufflehog ${args} ${repo}


### PR DESCRIPTION
When truffleHog is called with a `git_url` it [clones](https://github.com/trufflesecurity/truffleHog/blob/dev/truffleHog/truffleHog.py#L326) this url into a temporary directory. This leads to `origin` not pointing to the GitHub repo, but to the local CI clone. This can lead to [problems](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/1977). 

Using the `repo_path` argument, truffleHog uses the path directory without cloning it first. See https://github.com/trufflesecurity/truffleHog/commit/1a39f5ba0c2f5e507fc1452e070af0bb45f2ff28